### PR TITLE
Fix package name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ in your Elixir software.
 
 ## Installation
 
-Ensure that you have both `:timber` (version 3.0.0 or later) and `:timber_ecto` listed
+Ensure that you have both `:timber` (version 3.0.0 or later) and `:timber_exceptions` listed
 as dependencies in `mix.exs`:
 
 ```elixir


### PR DESCRIPTION
I'm guessing this was carried over from the very-similar `:timber_ecto` docs. A quick fix! Let me know if there are any tests/processes/etc you'd like me to follow to get this ready.